### PR TITLE
Add support for auto-fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Using this layer generally consists of the following steps:
   * Wait for `layer.docker-resource.{resource_name}.available`
   * Call `layer.docker_resource.get_info(resource_name)`
 
+Alternatively, a resource can be marked with `auto-fetch: true` in its
+definition in `metadata.yaml`, in which case it will automatically have
+`fetch()` called on it, if it is of type `docker`.  That way, you can
+skip the first step and remove the need for an additional handler.
+
 
 Example
 =======

--- a/reactive/docker_resource.py
+++ b/reactive/docker_resource.py
@@ -1,6 +1,18 @@
-from charms.reactive import when
+from charmhelpers.core import hookenv
+from charms.reactive import set_flag, when, when_not
 
 from charms import layer
+
+
+@when_not('layer.docker-resource.auto-fetched')
+def auto_fetch():
+    resources = hookenv.metadata().get('resources', {})
+    for name, resource in resources.items():
+        is_docker = resource.get('type') == 'docker'
+        is_auto_fetch = resource.get('auto-fetch', False)
+        if is_docker and is_auto_fetch:
+            layer.docker_resource.fetch(name)
+    set_flag('layer.docker-resource.auto-fetched')
 
 
 @when('layer.docker-resource.pending')


### PR DESCRIPTION
Add support for a resource to be marked `auto-fetch` flag to eliminate a boilerplate handler.

```yaml
resources:
  tf-operator-image:
    type: docker
    description: 'Image for tf-operator'
    auto-fetch: true
```

Makes this unnecessary:

```python
@when_not('layer.docker-resource.tf-operator-image.fetched')
def fetch_image():
    layer.docker_resource.fetch('tf-operator-image')
```